### PR TITLE
Removed groups_col parameter from PseudobulkSpace

### DIFF
--- a/perturbation_space.ipynb
+++ b/perturbation_space.ipynb
@@ -62,7 +62,7 @@
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[1;33mryp2 is not installed. Install with \u001b[0m\u001b[1;32mpip install rpy2 \u001b[0m\u001b[1;33mto run tools with R support.\u001b[0m\n"
+       "\u001B[1;33mryp2 is not installed. Install with \u001B[0m\u001B[1;32mpip install rpy2 \u001B[0m\u001B[1;33mto run tools with R support.\u001B[0m\n"
       ]
      },
      "metadata": {},
@@ -625,7 +625,6 @@
     "psadata = ps.compute(\n",
     "    adata,\n",
     "    target_col=\"perturbation_name\",\n",
-    "    groups_col=\"perturbation_name\",\n",
     "    mode=\"mean\",\n",
     "    min_cells=0,\n",
     "    min_counts=0,\n",
@@ -1046,7 +1045,6 @@
     "diff_psadata = ps.compute(\n",
     "    diff_adata,\n",
     "    target_col=\"perturbation_name\",\n",
-    "    groups_col=\"perturbation_name\",\n",
     "    mode=\"mean\",\n",
     "    min_cells=0,\n",
     "    min_counts=0,\n",
@@ -1306,9 +1304,9 @@
       ],
       "text/plain": [
        "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
-       "┃\u001b[1m \u001b[0m\u001b[1m       Test metric       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      DataLoader 0       \u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┃\u001B[1m \u001B[0m\u001B[1m       Test metric       \u001B[0m\u001B[1m \u001B[0m┃\u001B[1m \u001B[0m\u001B[1m      DataLoader 0       \u001B[0m\u001B[1m \u001B[0m┃\n",
        "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
-       "│\u001b[36m \u001b[0m\u001b[36m        test_loss        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m    2.326035976409912    \u001b[0m\u001b[35m \u001b[0m│\n",
+       "│\u001B[36m \u001B[0m\u001B[36m        test_loss        \u001B[0m\u001B[36m \u001B[0m│\u001B[35m \u001B[0m\u001B[35m    2.326035976409912    \u001B[0m\u001B[35m \u001B[0m│\n",
        "└───────────────────────────┴───────────────────────────┘\n"
       ]
      },
@@ -1394,7 +1392,6 @@
     "psadata = ps.compute(\n",
     "    pert_embeddings,\n",
     "    target_col=\"perturbations\",\n",
-    "    groups_col=\"perturbations\",\n",
     "    mode=\"mean\",\n",
     "    min_cells=0,\n",
     "    min_counts=0,\n",


### PR DESCRIPTION
Incorporates the modifications made in https://github.com/theislab/pertpy/pull/529 in the perturbation space tutorial, namely not specifying the `groups_col` parameter when computing the pseudobulk embedding of the data, as it has no effect on the computations.