### PR TITLE
Update to compute method for MLPClassifierSpace

### DIFF
--- a/perturbation_space.ipynb
+++ b/perturbation_space.ipynb
@@ -865,37 +865,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `load` method creates the model to train and the dataloaders.\n",
-    "It accepts different hyperparameters related with the architecture of the model such as `hidden_dim`, `dropout`, `batch_norm`, etc. \n",
-    "Training hyperparameters such as `batch_size`, `test_split_size`, `validation_split_size` can also be changed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-12-28T12:01:14.855980Z",
-     "start_time": "2023-12-28T12:01:10.228958Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "classifier_ps = ps.load(\n",
-    "    adata,\n",
-    "    target_col=\"perturbation_name\",\n",
-    "    hidden_dim=[512, 256],\n",
-    "    dropout=0.05,\n",
-    "    batch_size=64,\n",
-    "    batch_norm=True,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's train just for a few epochs to show the general idea. The trainer uses GPU if available."
+    "Next, we will create and train the model using the `compute` method. The method accepts different hyperparameters related with the architecture of the model such as `hidden_dim`, `dropout`, `batch_norm`, etc. Training hyperparameters such as `batch_size`, `test_split_size`, `validation_split_size` can also be changed.\n",
+    "The `compute` method trains the model, using GPU if available, and returns the embeddings of the data. The embeddings are the representation of each cell in the last layer of the neural network, which has a size of 256, as we define in the parameter `hidden_dim`. Hence, the embeddings represent a lower dimensional representation of the data."
    ]
   },
   {
@@ -1055,32 +1026,15 @@
     }
    ],
    "source": [
-    "classifier_ps.train(max_epochs=20)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "Next, we extract the embeddings of the data from the trained models.\n",
-    "The embeddings are the representation of each cell in the last layer of the model, which has a size of 256, as previously set.\n",
-    "Hence, the embeddings represent a lower dimensional representation of the data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-12-28T15:37:48.401087Z",
-     "start_time": "2023-12-28T15:37:41.760715Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "pert_embeddings = classifier_ps.get_embeddings()"
+    "cell_embeddings = ps.compute(\n",
+    "    adata,\n",
+    "    target_col=\"perturbation_name\",\n",
+    "    hidden_dim=[512, 256],\n",
+    "    dropout=0.05,\n",
+    "    batch_size=64,\n",
+    "    batch_norm=True,\n",
+    "    max_epochs=20,\n",
+    ")"
    ]
   },
   {
@@ -1106,14 +1060,14 @@
     }
    ],
    "source": [
-    "pert_embeddings.shape"
+    "cell_embeddings.shape"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The pert_embeddings object is of size (n_cells, 256).\n",
+    "The cell_embeddings object is of size (n_cells, 256).\n",
     "We can further analyze and visualize this space, by applying pseudobulk or any other transformation to obtain one datapoint per perturbation (an AnnData object with shape n_perturbations x 256)."
    ]
   },
@@ -1130,7 +1084,7 @@
    "source": [
     "ps = pt.tl.PseudobulkSpace()\n",
     "psadata = ps.compute(\n",
-    "    pert_embeddings,\n",
+    "    cell_embeddings,\n",
     "    target_col=\"perturbations\",\n",
     "    mode=\"mean\",\n",
     "    min_cells=0,\n",


### PR DESCRIPTION
Instead of the deprecated `load`, `train`, and `get_embeddings` methods, this PR uses the new `compute` method for the `MLPClassifierSpace` in the Perturbation Space tutorial. Additionally, we clarify that the `MLPClassifierSpace` generates per-cell embeddings, rather than per-perturbation embeddings.

Waiting for confirmation on [issue 566](https://github.com/theislab/pertpy/issues/566) and [PR 565](https://github.com/theislab/pertpy/pull/565) before merging.