### PR TITLE
guide_rna_assignment: drop stale CUDA-required callout

### DIFF
--- a/guide_rna_assignment.ipynb
+++ b/guide_rna_assignment.ipynb
@@ -686,7 +686,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
-    "⚠️ The Mixture Model guide assignment method will be very slow if JAX is not installed with CUDA support.\n",
+    "ℹ️ The mixture model fits all guides in parallel with JAX/optax and matches <a href=\"https://github.com/velten-group/crispat\">crispat</a>'s Poisson-Gaussian output. It runs in a few seconds for hundreds of guides on CPU; a GPU is not required.\n",
     "</div>"
    ]
   },


### PR DESCRIPTION
The mixture model in pertpy is now a JAX/optax MAP fit (scverse/pertpy#987) that runs all guides in parallel in a few seconds on CPU and matches crispat's Poisson-Gaussian output. The "very slow without CUDA" alert is no longer accurate; replaces it with a short note pointing at crispat.