### PR TITLE
Rename DistanceTest alpha to padj_threshold

### DIFF
--- a/distance_tests.ipynb
+++ b/distance_tests.ipynb
@@ -156,7 +156,7 @@
     }
    ],
    "source": [
-    "etest = pt.tl.DistanceTest(\"edistance\", n_perms=1000, obsm_key=\"X_pca\", alpha=0.0015)\n",
+    "etest = pt.tl.DistanceTest(\"edistance\", n_perms=1000, obsm_key=\"X_pca\", padj_threshold=0.0015)\n",
     "tab = etest(adata, groupby=obs_key, contrast=contrast)"
    ]
   },
@@ -165,7 +165,7 @@
    "metadata": {},
    "source": [
     "We recommend using the adjusted p-values, which are corrected for multiple testing.\n",
-    "You might have to specify a lower `alpha` value for the adjusted p-values to be significant, depending on the number of permutations, the number of cells in each group, and the number of groups tested (each group increases the number of tests made and therefore affects the adjusted p-value).\n",
+    "You might have to specify a lower `padj_threshold` value for the adjusted p-values to be significant, depending on the number of permutations, the number of cells in each group, and the number of groups tested (each group increases the number of tests made and therefore affects the adjusted p-value).\n",
     "Also note that the lowest p-value you can get is 1 / n_permutations, which is the probability of getting the observed distance by chance."
    ]
   },


### PR DESCRIPTION
Follows scverse/pertpy#1062, which renames `DistanceTest`'s `alpha` to `padj_threshold`.
`alpha` still works but emits a `FutureWarning`.