### PR TITLE
Replace deprecated pertpy API usage

### DIFF
--- a/differential_gene_expression.ipynb
+++ b/differential_gene_expression.ipynb
@@ -1229,7 +1229,7 @@
     "  This is the value to threshold on (commonly `< 0.05`).\n",
     "- `contrast` — identifier of the contrast when multiple are tested at once; `None` here because we only ran one contrast.\n",
     "\n",
-    "A standard summary is \"significantly differentially expressed\" = `adj_p_value < 0.05` **and** `|log_fc|` above some effect-size threshold (the volcano plot below uses `log2fc_thresh` for the latter).\n"
+    "A standard summary is \"significantly differentially expressed\" = `adj_p_value < 0.05` **and** `|log_fc|` above some effect-size threshold (the volcano plot below uses `log2fc_threshold` for the latter).\n"
    ]
   },
   {

--- a/mcfarland_use_case.ipynb
+++ b/mcfarland_use_case.ipynb
@@ -1827,10 +1827,10 @@
     "edgr.plot_volcano(\n",
     "    lr_params,\n",
     "    log2fc_col=\"intercept\",\n",
-    "    pvalue_col=\"intercept_pval_corrected\",\n",
+    "    padj_col=\"intercept_pval_corrected\",\n",
     "    symbol_col=\"gene\",\n",
-    "    pval_thresh=0.05,\n",
-    "    log2fc_thresh=0.5,\n",
+    "    padj_threshold=0.05,\n",
+    "    log2fc_threshold=0.5,\n",
     ")"
    ]
   },
@@ -1942,10 +1942,10 @@
     "edgr.plot_volcano(\n",
     "    lr_params,\n",
     "    log2fc_col=\"slope\",\n",
-    "    pvalue_col=\"slope_pval_corrected\",\n",
+    "    padj_col=\"slope_pval_corrected\",\n",
     "    symbol_col=\"gene\",\n",
-    "    pval_thresh=0.1,\n",
-    "    log2fc_thresh=0.1,\n",
+    "    padj_threshold=0.1,\n",
+    "    log2fc_threshold=0.1,\n",
     ")"
    ]
   },

--- a/milo.ipynb
+++ b/milo.ipynb
@@ -2135,7 +2135,7 @@
     "]  ## notice how here logFCs are much smaller\n",
     "\n",
     "## Add COVID severity labels to mdata['milo'].obs\n",
-    "milo.add_covariate_to_nhoods_var(mdata, [\"COVID_severity\"])\n",
+    "milo.add_covariate_to_nhoods_obs(mdata, [\"COVID_severity\"])\n",
     "mdata[\"milo\"].obs[\"COVID_severity\"] = (\n",
     "    mdata[\"milo\"].obs[\"COVID_severity\"].astype(\"category\").cat.reorder_categories(severity_order)\n",
     ")\n",


### PR DESCRIPTION
These have emitted a `FutureWarning` since the renames in scverse/pertpy#974:

- `milo.ipynb`: `add_covariate_to_nhoods_var` → `add_covariate_to_nhoods_obs`
- `mcfarland_use_case.ipynb`: `pvalue_col` → `padj_col`, `pval_thresh` → `padj_threshold`, `log2fc_thresh` → `log2fc_threshold`
- `differential_gene_expression.ipynb`: prose referring to `log2fc_thresh`, the code cells already use `log2fc_threshold`

Pure renames, so the stored outputs are unaffected.